### PR TITLE
Relax eslint config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,15 @@ module.exports = {
   'rules': {
     'strict': 0,
 
+    // Forbid multiple statements in one line
+    'max-statements-per-line': ["error", { "max": 1 }],
+
+    // Allow for-of loops
+    'no-restricted-syntax': ['error', 'ForInStatement', 'LabeledStatement', 'WithStatement'],
+
+    // Allow return before else & redundant else statements
+    'no-else-return': 'off',
+
     // allow dangling underscores for 'fields'
     'no-underscore-dangle': ['error', {'allowAfterThis': true}],
 


### PR DESCRIPTION
Allow for..of, allow redundant else statements
for style purposes.

Forbids multiple statements per line. This specifically
prevents the following construction which is equivalent
to using if..else if, but unusual to read and may introduce
errors when refactoring the code not to use return statements.
By allowing redundant else statements we can just use an
actual if..else if construction.

    if (foo) {
      return 42;
    } if (bar) {
      return 23;
    }

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
